### PR TITLE
Add environment field in asdf

### DIFF
--- a/docs/resources/asdf.md
+++ b/docs/resources/asdf.md
@@ -36,6 +36,10 @@ resource "installer_asdf" "this" {
 - `name` (String) is the name of the plugin. See `installer_asdf_plugin`.
 - `version` (String) is the version of the plugin that asdf should install.
 
+### Optional
+
+- `environment` (Map of String) are the environment variables set during the installation.
+
 ### Read-Only
 
 - `id` (String) Internal ID of the resource.

--- a/docs/resources/asdf_plugin.md
+++ b/docs/resources/asdf_plugin.md
@@ -28,6 +28,7 @@ resource "installer_asdf_plugin" "this" {
 
 ### Optional
 
+- `environment` (Map of String) are the environment variables set during the installation.
 - `git_url` (String) is the Git repository's URL which will be added as the plugin if specified.
 
 ### Read-Only

--- a/internal/asdf/asdf.go
+++ b/internal/asdf/asdf.go
@@ -11,8 +11,11 @@ import (
 	"github.com/shihanng/terraform-provider-installer/internal/xerrors"
 )
 
-func AddPlugin(ctx context.Context, name, gitURL string) error {
+func AddPlugin(ctx context.Context, name, gitURL string, env []string) error {
 	cmd := exec.CommandContext(ctx, "asdf", "plugin", "add", name, gitURL)
+
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, env...)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/asdf/asdf.go
+++ b/internal/asdf/asdf.go
@@ -3,6 +3,7 @@ package asdf
 import (
 	"bytes"
 	"context"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -62,8 +63,11 @@ func RemovePlugin(ctx context.Context, name string) error {
 	return nil
 }
 
-func Install(ctx context.Context, name, version string) error {
+func Install(ctx context.Context, name, version string, env []string) error {
 	cmd := exec.CommandContext(ctx, "asdf", "install", name, version)
+
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, env...)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/asdf/asdf_test.go
+++ b/internal/asdf/asdf_test.go
@@ -38,7 +38,7 @@ func TestASDF(t *testing.T) { //nolint:tparallel
 	})
 
 	t.Run("run asdf install", func(t *testing.T) { //nolint:paralleltest
-		err := asdf.Install(ctx, name, version)
+		err := asdf.Install(ctx, name, version, []string{})
 		t.Log(errors.FlattenDetails(err))
 		assert.NilError(t, err)
 	})

--- a/internal/asdf/asdf_test.go
+++ b/internal/asdf/asdf_test.go
@@ -28,7 +28,7 @@ func TestASDF(t *testing.T) { //nolint:tparallel
 	version := "0.25.2"
 
 	t.Run("run asdf plugin add", func(t *testing.T) { //nolint:paralleltest
-		assert.NilError(t, asdf.AddPlugin(ctx, name, gitURL))
+		assert.NilError(t, asdf.AddPlugin(ctx, name, gitURL, []string{}))
 	})
 
 	t.Run("run FindAddedPlugin", func(t *testing.T) { //nolint:paralleltest

--- a/internal/provider/resource_asdf.go
+++ b/internal/provider/resource_asdf.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/shihanng/terraform-provider-installer/internal/asdf"
@@ -76,16 +75,7 @@ func resourceASDFCreate(ctx context.Context, data *schema.ResourceData, meta int
 	version := data.Get("version").(string) // nolint:forcetypeassert
 	environment := data.Get("environment").(map[string]interface{})
 
-	env := make([]string, 0, len(environment))
-
-	for key, value := range environment {
-		tflog.Debug(ctx, "environment", map[string]interface{}{
-			"key":   key,
-			"value": value,
-		})
-
-		env = append(env, fmt.Sprintf("%s=%v", key, value))
-	}
+	env := getEnv(environment)
 
 	if err := asdf.Install(ctx, name, version, env); err != nil {
 		return xerrors.ToDiags(err)
@@ -141,4 +131,14 @@ func resourceASDFDelete(ctx context.Context, data *schema.ResourceData, m interf
 	data.SetId("")
 
 	return diags
+}
+
+func getEnv(environment map[string]interface{}) []string {
+	env := make([]string, 0, len(environment))
+
+	for key, value := range environment {
+		env = append(env, fmt.Sprintf("%s=%v", key, value))
+	}
+
+	return env
 }

--- a/internal/provider/resource_asdf_plugin.go
+++ b/internal/provider/resource_asdf_plugin.go
@@ -46,6 +46,15 @@ func resourceASDFPlugin() *schema.Resource {
 				ForceNew:    true,
 				Computed:    true,
 			},
+			"environment": {
+				Description: "are the environment variables set during the installation.",
+				Type:        schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				ForceNew: true,
+				Optional: true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -56,8 +65,11 @@ func resourceASDFPlugin() *schema.Resource {
 func resourceASDFPluginCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	name := data.Get("name").(string)      // nolint:forcetypeassert
 	gitURL := data.Get("git_url").(string) // nolint:forcetypeassert
+	environment := data.Get("environment").(map[string]interface{})
 
-	if err := asdf.AddPlugin(ctx, name, gitURL); err != nil {
+	env := getEnv(environment)
+
+	if err := asdf.AddPlugin(ctx, name, gitURL, env); err != nil {
 		return xerrors.ToDiags(err)
 	}
 


### PR DESCRIPTION
Users can include key-value pairs in this field to include environment variables during the asdf install.
